### PR TITLE
docs(faq): 2.0 DDS transport documentation

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -2,13 +2,37 @@
 
 ## Setup & Configuration
 
-### How do I connect Conduit to my ROS 2 system?
+### Which transport should I use: Zenoh or DDS?
+
+Conduit 2.0 supports two transports — choose based on your ROS 2 middleware:
+
+| | Zenoh | DDS (CycloneDDS) |
+|---|---|---|
+| **RMW** | rmw_zenoh_cpp | rmw_cyclonedds_cpp |
+| **Router required** | Yes (rmw_zenohd) | No |
+| **Network** | TCP/UDP to router | Multicast or unicast on LAN |
+| **Distros** | Humble, Jazzy, Kilted, Rolling | Jazzy, Kilted, Rolling |
+| **Setup** | Enter router IP in Settings | Set discovery mode in Settings |
+
+**Recommendation:** Use **Zenoh** if you already have rmw_zenoh_cpp set up. Use **DDS** if your stack uses rmw_cyclonedds_cpp and you want zero-broker operation.
+
+See [TRANSPORTS.md](TRANSPORTS.md) for a deeper side-by-side comparison and network-requirements reference.
+
+### I used Conduit 1.x — what changed in 2.0?
+
+**Topic namespace:** Default is now `/conduit/*` (was `ios/*`). If you have ROS 2 subscribers hardcoded to the old `ios` namespace, either remap in your subscriber or change the app's namespace in Settings.
+
+**Transport choice:** 2.0 adds DDS (CycloneDDS) alongside Zenoh. Existing Zenoh users can keep their current router setup — Zenoh remains fully supported. DDS is opt-in via Settings → Transport.
+
+**Supported distros:** Kilted and Rolling join Humble and Jazzy.
+
+### How do I connect via Zenoh?
 
 1. Start the Zenoh router on your ROS 2 system:
    ```bash
    source /opt/ros/jazzy/setup.bash
    export RMW_IMPLEMENTATION=rmw_zenoh_cpp
-   export ROS_DOMAIN_ID=0  # Set domain ID (0-255, default: 0)
+   export ROS_DOMAIN_ID=0  # Set domain ID (0-232, default: 0)
    ros2 run rmw_zenoh_cpp rmw_zenohd
    ```
 
@@ -28,7 +52,7 @@
 
 4. Enable sensors and tap Play
 
-**Important:** Domain ID must match between the app and ROS 2 system. Valid range: 0-255.
+**Important:** Domain ID must match between the app and ROS 2 system. Valid range: 0-232 (RTPS specification limit).
 
 ### Which ROS 2 versions are supported?
 
@@ -51,7 +75,7 @@ All versions require rmw_zenoh_cpp middleware. The app auto-detects which versio
    ```
    - Domain ID in app Settings must match ROS_DOMAIN_ID on host
    - Default is 0 if not set
-   - Valid range: 0-255
+   - Valid range: 0-232 (RTPS specification limit)
 
 2. **Zenoh router not running**:
    ```bash
@@ -131,16 +155,16 @@ On your ROS 2 system:
 
 ```bash
 # Check if topic appears
-ros2 topic list | grep ios
+ros2 topic list | grep conduit
 
 # Echo data from IMU sensor
-ros2 topic echo /ios/imu
+ros2 topic echo /conduit/imu
 
 # Check publish rate
-ros2 topic hz /ios/imu
+ros2 topic hz /conduit/imu
 
 # View topic info
-ros2 topic info /ios/imu --verbose
+ros2 topic info /conduit/imu --verbose
 ```
 
 ### Why is my sensor showing "Not Available"?
@@ -170,10 +194,10 @@ Yes! Conduit supports multi-camera streaming:
 1. Tap the Camera sensor row
 2. Select multiple cameras (front, wide, ultra-wide, telephoto)
 3. Each camera publishes to separate topic:
-   - `/ios/camera/front/compressed`
-   - `/ios/camera/wide/compressed`
-   - `/ios/camera/ultrawide/compressed`
-   - `/ios/camera/telephoto/compressed`
+   - `/conduit/camera/front/compressed`
+   - `/conduit/camera/wide/compressed`
+   - `/conduit/camera/ultrawide/compressed`
+   - `/conduit/camera/telephoto/compressed`
 
 **Note:** Wide, ultra-wide, and telephoto cameras require Premium unlock.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -54,6 +54,30 @@ See [TRANSPORTS.md](TRANSPORTS.md) for a deeper side-by-side comparison and netw
 
 **Important:** Domain ID must match between the app and ROS 2 system. Valid range: 0-232 (RTPS specification limit).
 
+### How do I connect via DDS?
+
+1. On your ROS 2 system:
+   ```bash
+   source /opt/ros/jazzy/setup.bash
+   export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+   export ROS_DOMAIN_ID=0  # Valid range: 0-232
+   ros2 topic list
+   ```
+
+2. In the Conduit app:
+   - Tap Settings → Transport: **DDS**
+   - Discovery Mode: **Hybrid** (recommended) or Unicast
+   - Add the ROS 2 host IP to Unicast Peers
+   - **Network Interface: `en0`** (required on iOS — do not leave as "auto")
+   - Domain ID: must match `ROS_DOMAIN_ID`
+   - Tap Save
+
+3. Enable sensors and tap Play
+
+**Important:**
+- Domain ID must match between the app and ROS 2 system. Valid range: **0-232** (DDS RTPS limit).
+- On iOS, DDS **requires** binding to `en0` (WiFi) — multicast / auto-select often fails.
+
 ### Which ROS 2 versions are supported?
 
 Conduit supports:
@@ -62,7 +86,9 @@ Conduit supports:
 - **ROS 2 Kilted** (Ubuntu 24.04) - RIHS01 type hash
 - **ROS 2 Rolling** - RIHS01 type hash
 
-All versions require rmw_zenoh_cpp middleware. The app auto-detects which version you're using. Iron and later distributions use RIHS01 type hash for message type verification.
+Supported RMW implementations:
+- **rmw_zenoh_cpp** — via Zenoh transport (the app auto-detects Humble vs Jazzy wire format)
+- **rmw_cyclonedds_cpp 0.10.5** — via DDS transport (default RMW on many ROS 2 distributions)
 
 ### Why can't I see my topics in `ros2 topic list`?
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -20,8 +20,6 @@ See [TRANSPORTS.md](TRANSPORTS.md) for a deeper side-by-side comparison and netw
 
 ### I used Conduit 1.x — what changed in 2.0?
 
-**Topic namespace:** Default is now `/conduit/*` (was `/ios/*`). If you have ROS 2 subscribers hardcoded to the old `ios` namespace, either remap in your subscriber or change the app's namespace in Settings.
-
 **Transport choice:** 2.0 adds DDS (CycloneDDS) alongside Zenoh. Existing Zenoh users can keep their current router setup — Zenoh remains fully supported. DDS is opt-in via Settings → Transport.
 
 **Supported distros:** Kilted and Rolling join Humble and Jazzy.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -11,7 +11,7 @@ Conduit 2.0 supports two transports — choose based on your ROS 2 middleware:
 | **RMW** | rmw_zenoh_cpp | rmw_cyclonedds_cpp |
 | **Router required** | Yes (rmw_zenohd) | No |
 | **Network** | TCP/UDP to router | Multicast or unicast on LAN |
-| **Distros** | Humble, Jazzy, Kilted, Rolling | Jazzy, Kilted, Rolling |
+| **Distros** | Humble, Jazzy, Kilted, Rolling | Humble, Jazzy, Kilted, Rolling |
 | **Setup** | Enter router IP in Settings | Set discovery mode in Settings |
 
 **Recommendation:** Use **Zenoh** if you already have rmw_zenoh_cpp set up. Use **DDS** if your stack uses rmw_cyclonedds_cpp and you want zero-broker operation.
@@ -20,7 +20,7 @@ See [TRANSPORTS.md](TRANSPORTS.md) for a deeper side-by-side comparison and netw
 
 ### I used Conduit 1.x — what changed in 2.0?
 
-**Topic namespace:** Default is now `/conduit/*` (was `ios/*`). If you have ROS 2 subscribers hardcoded to the old `ios` namespace, either remap in your subscriber or change the app's namespace in Settings.
+**Topic namespace:** Default is now `/conduit/*` (was `/ios/*`). If you have ROS 2 subscribers hardcoded to the old `ios` namespace, either remap in your subscriber or change the app's namespace in Settings.
 
 **Transport choice:** 2.0 adds DDS (CycloneDDS) alongside Zenoh. Existing Zenoh users can keep their current router setup — Zenoh remains fully supported. DDS is opt-in via Settings → Transport.
 
@@ -61,7 +61,7 @@ See [TRANSPORTS.md](TRANSPORTS.md) for a deeper side-by-side comparison and netw
    source /opt/ros/jazzy/setup.bash
    export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
    export ROS_DOMAIN_ID=0  # Valid range: 0-232
-   ros2 topic list
+   ros2 topic list  # Verify the RMW is active (no topics expected yet)
    ```
 
 2. In the Conduit app:
@@ -136,10 +136,9 @@ Yes, for testing:
 - You can verify app functionality without ROS 2
 - However, you won't be able to receive data without a Zenoh router
 
-For production use, you need:
-- ROS 2 Humble, Jazzy, Kilted, or Rolling
-- rmw_zenoh_cpp middleware
-- Zenoh router running
+For production use, you need a ROS 2 system (Humble, Jazzy, Kilted, or Rolling) with **one** of the supported transports:
+- **Zenoh:** `rmw_zenoh_cpp` middleware and a running Zenoh router (`rmw_zenohd`).
+- **DDS:** `rmw_cyclonedds_cpp` middleware on the same LAN as your iOS device — no broker required.
 
 ### Which sensors work on which platforms?
 


### PR DESCRIPTION
## Summary

- Add Zenoh vs DDS transport selection guide and DDS connection steps
- Fix ROS_DOMAIN_ID range from 0-255 to 0-232 (RTPS specification limit)
- Replace /ios/* topic references with /conduit/* (2.0 default namespace)
- Add 'Upgrading from 1.x' Q&A
- Add Kilted and Rolling to supported distros
- Link to docs/TRANSPORTS.md (added in a follow-up Phase 3 PR)

## Phase

This is **Phase 1 of 4** in the Conduit Support 2.0 documentation update. Subsequent PRs will follow:
- Phase 2: TROUBLESHOOTING.md + KNOWN_ISSUES.md (DDS issues)
- Phase 3: README.md + new TRANSPORTS.md + PLATFORM_NOTES.md
- Phase 4: Docker DDS environment (compose-dds.yml)

## Test plan

- [x] grep -nE "(/ios/|0-255)" docs/FAQ.md returns empty
- [ ] Visual review of new Q&As renders correctly on GitHub