### PR TITLE
docs(troubleshooting): DDS issues and known limitations for 2.0

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -157,6 +157,50 @@ Current limitations and known issues in Conduit.
 
 ---
 
+## DDS Transport
+
+### Camera/LiDAR fragmentation loss on DDS over WiFi
+
+**Status:** Known limitation
+
+**Reason:** Large RTPS messages (>1400 bytes — camera, LiDAR, CameraInfo with large K matrices) are split into UDP fragments. Consumer WiFi often drops or reorders fragments, especially over multicast.
+
+**Mitigation:**
+- Use **Unicast** or **Hybrid** discovery mode (Settings → Transport → DDS → Discovery Mode).
+- Reduce camera resolution or LiDAR point density.
+- Use wired Ethernet on the ROS 2 host if possible.
+
+### CameraInfo requires BestEffort subscriber QoS
+
+**Status:** By design
+
+**Reason:** CameraInfo publishes with `BestEffort + TransientLocal` QoS (`latchedBestEffort`) to match DDS behavior on iOS. Standard `image_transport` subscribers default to `Reliable`, which does not match.
+
+**Workaround:** Override the subscriber QoS:
+```bash
+ros2 topic echo /conduit/camera/front/camera_info \
+  --qos-reliability best_effort \
+  --qos-durability transient_local
+```
+
+### Disconnect delay on DDS (up to ~5 seconds)
+
+**Status:** Workaround in place
+
+**Reason:** DDS participant deletion is serialized on iOS to avoid a platform-specific deadlock in CycloneDDS's teardown path.
+
+**Behavior:** Pressing Stop in the app can take 2-5 seconds to fully release the domain. This is intentional and safe.
+
+### DDS requires WiFi — no cellular fallback
+
+**Status:** By design
+
+**Reason:** DDS discovery binds to a specific network interface (`en0` on iOS). Cellular or VPN interfaces are not supported; multicast/unicast discovery requires the device and the ROS 2 host to be on the same LAN.
+
+**Workaround:** Use Zenoh transport with a public router address if cross-network/WAN operation is required.
+
+---
+
 ## Premium Features
 
 ### Premium Purchase Required for Some Sensors

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -161,22 +161,22 @@ Current limitations and known issues in Conduit.
 
 ### Camera/LiDAR fragmentation loss on DDS over WiFi
 
-**Status:** Known limitation
+**Status**: Known limitation
 
-**Reason:** Large RTPS messages (>1400 bytes — camera, LiDAR, CameraInfo with large K matrices) are split into UDP fragments. Consumer WiFi often drops or reorders fragments, especially over multicast.
+**Reason**: Large RTPS messages (>1400 bytes — camera, LiDAR, CameraInfo with large K matrices) are split into UDP fragments. Consumer WiFi often drops or reorders fragments, especially over multicast.
 
-**Mitigation:**
+**Mitigation**:
 - Use **Unicast** or **Hybrid** discovery mode (Settings → Transport → DDS → Discovery Mode).
 - Reduce camera resolution or LiDAR point density.
 - Use wired Ethernet on the ROS 2 host if possible.
 
 ### CameraInfo requires BestEffort subscriber QoS
 
-**Status:** By design
+**Status**: By design
 
-**Reason:** CameraInfo publishes with `BestEffort + TransientLocal` QoS (`latchedBestEffort`) to match DDS behavior on iOS. Standard `image_transport` subscribers default to `Reliable`, which does not match.
+**Reason**: CameraInfo publishes with `BestEffort + TransientLocal` QoS (`latchedBestEffort`) to match DDS behavior on iOS. Standard `image_transport` subscribers default to `Reliable`, which does not match.
 
-**Workaround:** Override the subscriber QoS:
+**Workaround**: Override the subscriber QoS:
 ```bash
 ros2 topic echo /conduit/camera/front/camera_info \
   --qos-reliability best_effort \
@@ -185,19 +185,19 @@ ros2 topic echo /conduit/camera/front/camera_info \
 
 ### Disconnect delay on DDS (up to ~5 seconds)
 
-**Status:** Workaround in place
+**Status**: Workaround in place
 
-**Reason:** DDS participant deletion is serialized on iOS to avoid a platform-specific deadlock in CycloneDDS's teardown path.
+**Reason**: DDS participant deletion is serialized on iOS to avoid a platform-specific deadlock in CycloneDDS's teardown path.
 
-**Behavior:** Pressing Stop in the app can take 2-5 seconds to fully release the domain. This is intentional and safe.
+**Behavior**: Pressing Stop in the app can take 2-5 seconds to fully release the domain. This is intentional and safe.
 
 ### DDS requires WiFi — no cellular fallback
 
-**Status:** By design
+**Status**: By design
 
-**Reason:** DDS discovery binds to a specific network interface (`en0` on iOS). Cellular or VPN interfaces are not supported; multicast/unicast discovery requires the device and the ROS 2 host to be on the same LAN.
+**Reason**: DDS discovery binds to a specific network interface (`en0` on iOS). Cellular or VPN interfaces are not supported; multicast/unicast discovery requires the device and the ROS 2 host to be on the same LAN.
 
-**Workaround:** Use Zenoh transport with a public router address if cross-network/WAN operation is required.
+**Workaround**: Use Zenoh transport with a public router address if cross-network/WAN operation is required.
 
 ---
 
@@ -241,6 +241,10 @@ ros2 topic echo /conduit/camera/front/camera_info \
 | Memory warnings | Reduce active sensors |
 | Thermal throttling | Lower rates, fewer sensors |
 | Connection slow | Wait 5 seconds for establishment |
+| DDS fragmentation loss on WiFi | Use Unicast or Hybrid discovery; lower camera/LiDAR resolution |
+| CameraInfo QoS mismatch | Subscriber: `--qos-reliability best_effort --qos-durability transient_local` |
+| DDS disconnect delay | Expected behavior — no user action required |
+| DDS over WAN / cellular | Use Zenoh transport with a public router instead |
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -2,7 +2,7 @@
 
 Common issues and solutions for Conduit.
 
-> **Which transport are you using?** Check Settings → Transport in the Conduit app. Zenoh and DDS have different failure modes. Zenoh issues are under "## Connection Issues" and "## Topic Issues" below; DDS-specific issues are in "## DDS Transport Issues" near the bottom of this page.
+> **Which transport are you using?** Check Settings → Transport in the Conduit app. Zenoh and DDS have different failure modes. Zenoh issues are under "## Connection Issues" and "## Topic Issues" below; DDS-specific issues are in "## DDS Transport Issues" at the bottom of this page.
 
 ## Connection Issues
 
@@ -374,13 +374,13 @@ Common issues and solutions for Conduit.
 
 2. **CameraInfo reliability:** CameraInfo uses BestEffort with TransientLocal (`latchedBestEffort`). Standard `image_transport` subscribers expect Reliable — override the subscriber QoS.
 
-3. **Large messages (Camera, LiDAR):** Use Unicast discovery. Multicast reassembly of fragmented RTPS data over consumer WiFi is unreliable — see KNOWN_ISSUES.md.
+3. **Large messages (Camera, LiDAR):** Use Unicast discovery. Multicast reassembly of fragmented RTPS data over consumer WiFi is unreliable — see [KNOWN_ISSUES.md](KNOWN_ISSUES.md).
 
 ### Disconnect takes several seconds (DDS)
 
 **Problem:** Pressing Stop in the app causes a 2-5 second delay before "Publishing" clears.
 
-**Expected behavior:** DDS disconnect is serialized to avoid an iOS-specific participant-delete deadlock. See KNOWN_ISSUES.md.
+**Expected behavior:** DDS disconnect is serialized to avoid an iOS-specific participant-delete deadlock. See [KNOWN_ISSUES.md](KNOWN_ISSUES.md).
 
 ### iOS cannot reach the ROS 2 host (DDS over LAN)
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -2,6 +2,8 @@
 
 Common issues and solutions for Conduit.
 
+> **Which transport are you using?** Check Settings → Transport in the Conduit app. Zenoh and DDS have different failure modes. Zenoh issues are under "## Connection Issues" and "## Topic Issues" below; DDS-specific issues are in "## DDS Transport Issues" near the bottom of this page.
+
 ## Connection Issues
 
 ### "Connection Failed: Timeout"
@@ -99,7 +101,7 @@ Common issues and solutions for Conduit.
    docker exec ros_jazzy_zenoh bash -c "echo \$ROS_DOMAIN_ID"
    ```
    - Domain ID in app Settings must match ROS_DOMAIN_ID on host
-   - Valid range: 0-255
+   - Valid range: 0-232 (RTPS specification limit)
    - Default is 0 if not set
 
 2. **Verify RMW_IMPLEMENTATION**:
@@ -326,6 +328,68 @@ Common issues and solutions for Conduit.
 2. **Timezone**: ROS 2 uses UTC, iOS uses local time
 
 3. **Timestamp source**: Verify using correct time source (system vs sensor)
+
+## DDS Transport Issues
+
+### No topics appear when using DDS
+
+**Problem:** App shows "Publishing" but `ros2 topic list` on the ROS 2 host returns nothing.
+
+**Solutions:**
+
+1. **Verify RMW implementation:**
+   ```bash
+   echo $RMW_IMPLEMENTATION
+   # Must be: rmw_cyclonedds_cpp
+   ```
+
+2. **Check domain IDs match** (0-232 valid range for DDS/RTPS):
+   ```bash
+   echo $ROS_DOMAIN_ID
+   ```
+   Must match the Domain ID field in Conduit Settings.
+
+3. **Verify network interface binding on iOS:**
+   - Conduit Settings → Transport → DDS → Network Interface must be `en0` (WiFi).
+   - Leaving this as "auto" frequently fails because iOS may select a cellular or VPN interface.
+
+4. **Multicast blocked by WiFi AP:**
+   - Many consumer access points enable "AP isolation" or drop multicast.
+   - Workaround: switch Discovery Mode to **Unicast** and add the ROS 2 host IP to the Unicast Peers list in Settings.
+
+5. **Firewall on ROS 2 host:**
+   - DDS uses UDP ports starting at `7400 + 250 * domain_id` (for domain 0: 7400, 7401, 7410, 7411).
+   - Allow UDP on those ports, or disable the firewall for the test LAN.
+
+### Topics appear but `ros2 topic echo` shows no data (DDS)
+
+**Problem:** Discovery works but data does not flow.
+
+**Solutions:**
+
+1. **QoS mismatch:** Conduit uses BestEffort reliability for high-rate sensors (IMU, camera). If your subscriber requests Reliable, it will not match. Use `--qos-profile sensor_data` or `--qos-reliability best_effort` on the subscriber:
+   ```bash
+   ros2 topic echo /conduit/imu --qos-reliability best_effort
+   ```
+
+2. **CameraInfo reliability:** CameraInfo uses BestEffort with TransientLocal (`latchedBestEffort`). Standard `image_transport` subscribers expect Reliable — override the subscriber QoS.
+
+3. **Large messages (Camera, LiDAR):** Use Unicast discovery. Multicast reassembly of fragmented RTPS data over consumer WiFi is unreliable — see KNOWN_ISSUES.md.
+
+### Disconnect takes several seconds (DDS)
+
+**Problem:** Pressing Stop in the app causes a 2-5 second delay before "Publishing" clears.
+
+**Expected behavior:** DDS disconnect is serialized to avoid an iOS-specific participant-delete deadlock. See KNOWN_ISSUES.md.
+
+### iOS cannot reach the ROS 2 host (DDS over LAN)
+
+**Problem:** `ping` from iOS to host works, but DDS discovery fails.
+
+**Solutions:**
+- Confirm both devices are on the same subnet; DDS default transport is UDP, which does not cross routers without configuration.
+- Corporate networks often block multicast and inter-client UDP. Use a dedicated test LAN or phone hotspot.
+- On macOS Docker Desktop, the Docker container **cannot** receive DDS from iOS because Docker Desktop does not provide true host networking. Run the subscriber on Linux, a Parallels VM, or natively on macOS instead.
 
 ## Getting More Help
 


### PR DESCRIPTION
## Summary

- TROUBLESHOOTING.md: add a top-of-doc transport selector and a new 'DDS Transport Issues' section (discovery failure, QoS mismatch, disconnect delay, LAN requirements, macOS Docker Desktop limitation).
- KNOWN_ISSUES.md: document 4 user-facing DDS behaviors (fragmentation loss on WiFi, CameraInfo BestEffort QoS, disconnect delay, cellular/VPN incompatibility).
- Replace /ios/* topic references with /conduit/* (2.0 namespace) in both files.
- Fix ROS_DOMAIN_ID range from 0-255 to 0-232 (RTPS limit).

## Phase

This is **Phase 2 of 4** in the Conduit Support 2.0 documentation update.
- Phase 1 (#11): docs/FAQ.md
- Phase 3 (upcoming): README.md, new docs/TRANSPORTS.md, PLATFORM_NOTES.md
- Phase 4 (upcoming): Docker DDS environment

## Test plan

- [x] grep -nE "/ios/|0-255" docs/TROUBLESHOOTING.md docs/KNOWN_ISSUES.md returns empty
- [ ] Visual review of new sections renders correctly on GitHub