### PR TITLE
docs(readme): 2.0 transports overview, README, platform notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Transform your Apple devices into ROS 2 sensor publishers**
 
-Stream real-time sensor data directly to your robotics system via Zenoh — no bridge required.
+Stream real-time sensor data directly to your robotics system via **Zenoh** or **DDS** — pick the transport that matches your ROS 2 setup.
 
 [![Download on App Store](https://img.shields.io/badge/Download-App%20Store-blue?style=for-the-badge&logo=apple)](https://apps.apple.com/jp/app/conduit-powered-by-ros/id6757171237?l=en-US)
 [![ROS 2](https://img.shields.io/badge/ROS%202-Humble%20|%20Jazzy%20|%20Kilted%20|%20Rolling-green?style=for-the-badge)](https://ros.org)
@@ -52,6 +52,15 @@ Stream real-time sensor data directly to your robotics system via Zenoh — no b
 | iOS/iPadOS 16+ | All 12 sensors |
 | visionOS 1+ | Camera, IMU, Game Controller |
 | macOS 13+ | Camera, Battery, Game Controller |
+
+### Transports
+
+| Transport | ROS 2 RMW | Bridge required | Best for |
+|-----------|-----------|-----------------|----------|
+| **Zenoh** | `rmw_zenoh_cpp` | Yes (Zenoh router) | Cross-subnet, WAN, corporate networks |
+| **DDS**   | `rmw_cyclonedds_cpp` | No (direct) | Same-LAN, standard ROS 2 |
+
+See [TRANSPORTS.md](docs/TRANSPORTS.md) for a detailed comparison.
 
 ### 12 Sensor Types
 
@@ -124,90 +133,79 @@ Stream real-time sensor data directly to your robotics system via Zenoh — no b
 ## Quick Start
 
 1. **Download** from [App Store](https://apps.apple.com/jp/app/conduit-powered-by-ros/id6757171237?l=en-US)
-2. **Start Zenoh Router** on your ROS 2 system with domain ID:
+2. **Choose your transport** — see [TRANSPORTS.md](docs/TRANSPORTS.md)
+
+### Quick Start — Zenoh
+
+1. Start the Zenoh router on your ROS 2 system:
    ```bash
-   export ROS_DOMAIN_ID=0  # Set domain ID (0-255, default: 0)
+   source /opt/ros/jazzy/setup.bash
+   export RMW_IMPLEMENTATION=rmw_zenoh_cpp
+   export ROS_DOMAIN_ID=0  # Valid range: 0-232
    ros2 run rmw_zenoh_cpp rmw_zenohd
    ```
-3. **Configure** connection in Settings:
-   - Router Address (e.g., `tcp/192.168.1.100:7447`)
-   - Domain ID (must match ROS_DOMAIN_ID on host)
-4. **Enable** sensors you want to stream
-5. **Tap Play** and verify with `ros2 topic echo /conduit/imu`
+2. In the Conduit app: Settings → Transport: **Zenoh**, enter the host IP and port `7447`, set Domain ID to match.
+3. Enable sensors and tap Play.
+4. Verify: `ros2 topic echo /conduit/imu`
+
+### Quick Start — DDS
+
+1. On your ROS 2 host:
+   ```bash
+   source /opt/ros/jazzy/setup.bash
+   export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+   export ROS_DOMAIN_ID=0  # Valid range: 0-232
+   ros2 topic list
+   ```
+2. In the Conduit app: Settings → Transport: **DDS**, Discovery Mode: **Hybrid**, add the host IP to Unicast Peers, Network Interface: `en0`, set Domain ID to match.
+3. Enable sensors and tap Play.
+4. Verify: `ros2 topic echo /conduit/imu --qos-reliability best_effort`
 
 ---
 
-## Zenoh Router (Docker)
+## Docker Test Environments
 
-### Quick Start (Pre-built Image)
+### Zenoh Router (Docker)
 
+Pre-built images on ghcr.io:
 ```bash
-# ROS 2 Jazzy (default domain ID: 0)
+# ROS 2 Jazzy
 docker run -d -p 7447:7447 --name ros_jazzy_zenoh ghcr.io/youtalk/conduit-support:jazzy
-
-# ROS 2 Humble (default domain ID: 0)
+# ROS 2 Humble
 docker run -d -p 7447:7447 --name ros_humble_zenoh ghcr.io/youtalk/conduit-support:humble
-
-# With custom domain ID
-docker run -d -p 7447:7447 -e ROS_DOMAIN_ID=5 --name ros_jazzy_zenoh ghcr.io/youtalk/conduit-support:jazzy
 ```
 
-### Using Docker Compose
-
+Or with Docker Compose:
 ```bash
 git clone https://github.com/youtalk/conduit-support.git
 cd conduit-support/docker
-
-# Start with default domain ID (0)
+echo "ROS_DOMAIN_ID=0" > .env
 docker compose up ros-jazzy -d
-
-# Start with custom domain ID
-ROS_DOMAIN_ID=5 docker compose up ros-jazzy -d
-
-# Or use .env file (recommended)
-echo "ROS_DOMAIN_ID=5" > .env
-docker compose up ros-jazzy -d
-
-# Stop
-docker compose down
 ```
 
-**Note:** Domain ID must match between container and iOS app (valid range: 0-255).
+### DDS Subscriber (Docker, Linux only)
 
-### Verify Connection
+> **macOS note:** Docker Desktop on macOS does not provide true host networking, so the container cannot receive DDS traffic from an iOS device on the same LAN. On macOS, run your DDS subscriber natively or in a Parallels/UTM VM.
 
 ```bash
-# Check topics
-docker exec ros_jazzy_zenoh bash -c \
-  "source /opt/ros/jazzy/setup.bash && ros2 topic list"
+cd conduit-support/docker
+echo "ROS_DOMAIN_ID=0" > .env
+docker compose -f compose-dds.yml up -d
 
-# Echo IMU data
-docker exec ros_jazzy_zenoh bash -c \
-  "source /opt/ros/jazzy/setup.bash && ros2 topic echo /conduit/imu"
-
-# Echo Microphone data (audio_common_msgs pre-installed in Docker image)
-docker exec ros_jazzy_zenoh bash -c \
-  "source /opt/ros/jazzy/setup.bash && \
-   source /ros2_ws/install/setup.bash && \
-   export RMW_IMPLEMENTATION=rmw_zenoh_cpp && \
-   ros2 topic echo /conduit/audio audio_common_msgs/msg/AudioData"
+# Verify
+docker exec -it ros_jazzy_dds bash
+source /opt/ros/jazzy/setup.bash
+ros2 topic list
+ros2 topic echo /conduit/imu --qos-reliability best_effort
 ```
 
-### Configure Conduit App
-
-1. Find the host machine's IP address: `ifconfig | grep inet` (macOS/Linux) or `ipconfig` (Windows)
-2. Get container's domain ID: `docker exec ros_jazzy_zenoh bash -c "echo \$ROS_DOMAIN_ID"`
-3. In Conduit Settings, configure:
-   - Router Address: `tcp/<HOST_IP>:7447`
-   - Domain ID: Match the container's domain ID (default: 0)
-4. Tap Play to connect
-
-**Troubleshooting:** If topics don't appear, verify both sides use the same domain ID.
+See [docker/README.md](docker/README.md) for the complete Docker guide. The `compose-dds.yml` file is added in a follow-up Phase 4 PR.
 
 ---
 
 ## Documentation
 
+- [Transports](docs/TRANSPORTS.md) - Zenoh vs DDS comparison and when to use each
 - [FAQ](docs/FAQ.md) - Frequently asked questions
 - [Troubleshooting Guide](docs/TROUBLESHOOTING.md) - Common issues and solutions
 - [Platform Notes](docs/PLATFORM_NOTES.md) - Platform-specific information

--- a/README.md
+++ b/README.md
@@ -179,8 +179,19 @@ Or with Docker Compose:
 ```bash
 git clone https://github.com/youtalk/conduit-support.git
 cd conduit-support/docker
-echo "ROS_DOMAIN_ID=0" > .env
+
+# Default domain ID (0)
 docker compose up ros-jazzy -d
+
+# Custom domain ID via .env (recommended for persistence)
+echo "ROS_DOMAIN_ID=5" > .env
+docker compose up ros-jazzy -d
+
+# Or override per-invocation
+ROS_DOMAIN_ID=5 docker compose up ros-jazzy -d
+
+# Stop
+docker compose down
 ```
 
 ### DDS Subscriber (Docker, Linux only)

--- a/docs/PLATFORM_NOTES.md
+++ b/docs/PLATFORM_NOTES.md
@@ -31,6 +31,11 @@ Information about sensor availability and limitations on different Apple platfor
 - ❌ Camera, LiDAR, Microphone (iOS restriction)
 - ⚠️ Background processing mode available for continuous streaming
 
+**DDS Transport on iOS:**
+- The app must bind to the `en0` (WiFi) interface for DDS discovery; cellular and VPN interfaces are not supported.
+- Multicast discovery may fail on consumer WiFi access points with "AP isolation" enabled — use Unicast or Hybrid mode.
+- DDS does not cross NAT or subnet boundaries; use Zenoh for cross-subnet scenarios.
+
 ---
 
 ## visionOS (Apple Vision Pro)

--- a/docs/TRANSPORTS.md
+++ b/docs/TRANSPORTS.md
@@ -1,0 +1,65 @@
+# Transports: Zenoh vs DDS
+
+Conduit 2.0 supports two transports for publishing ROS 2 messages. This page helps you pick one and configure it correctly.
+
+## Quick Decision
+
+| Your ROS 2 setup | Recommended transport |
+|------------------|-----------------------|
+| Uses `rmw_zenoh_cpp` | **Zenoh** |
+| Uses `rmw_cyclonedds_cpp` (default on Jazzy/Humble) | **DDS** |
+| Needs to cross subnets / WAN | **Zenoh** (run a router with a public IP) |
+| Same-LAN, no bridge infrastructure | **DDS** |
+| Corporate network blocking multicast | **Zenoh** (TCP) |
+
+## Side-by-side
+
+| | Zenoh | DDS (CycloneDDS) |
+|---|-------|-------------------|
+| ROS 2 RMW | `rmw_zenoh_cpp` | `rmw_cyclonedds_cpp` |
+| Bridge required | Yes (Zenoh router, `rmw_zenohd`) | No |
+| Discovery | Via router | Multicast, Unicast, or Hybrid |
+| Transport | TCP (default 7447) | UDP (7400 + 250 * domain_id, and neighbors) |
+| Cross-subnet | Yes | No (LAN only) |
+| Works through NAT | Yes (with router on public IP) | No |
+| iOS network interface | Any reachable interface | **Must bind to `en0` (WiFi)** |
+| Cellular / VPN | Works (TCP egress) | Not supported |
+| Domain ID range | 0-232 | 0-232 |
+| Large messages | Router handles fragmentation | UDP fragmentation (WiFi may drop) |
+| Setup complexity | Router needed | Direct |
+
+## Configuration at a Glance
+
+**Zenoh:**
+- Settings → Transport: **Zenoh**
+- Router Address: `<host-ip>`
+- Router Port: `7447`
+- Domain ID: match `ROS_DOMAIN_ID` on host
+
+**DDS:**
+- Settings → Transport: **DDS**
+- Discovery Mode: **Hybrid** (recommended) / Multicast / Unicast
+- Unicast Peers: add the ROS 2 host IP (required for Unicast/Hybrid)
+- Network Interface: `en0` (do **not** use auto)
+- Domain ID: match `ROS_DOMAIN_ID` on host
+
+## Network Requirements
+
+- **Zenoh:** iOS device and ROS 2 host must be able to establish a TCP connection to the Zenoh router on port 7447.
+- **DDS:** iOS device and ROS 2 host must be on the same LAN subnet, with UDP traffic permitted on DDS ports (`7400 + 250 * domain_id` and adjacent). Multicast reachability is required for Multicast/Hybrid modes. Consumer APs with "AP isolation" enabled will block peer-to-peer UDP — use Unicast mode, or disable AP isolation.
+
+## When to switch
+
+Use Zenoh if:
+- You hit fragmentation drops on DDS with large Camera/LiDAR messages.
+- You need to connect from outside the LAN.
+- Your WiFi AP blocks multicast and you cannot change it.
+
+Use DDS if:
+- Your ROS 2 nodes already use CycloneDDS and you don't want to install a Zenoh router.
+- You want the shortest network path (no extra hop through a router).
+
+See also:
+- [FAQ.md](FAQ.md) — setup Q&A
+- [TROUBLESHOOTING.md](TROUBLESHOOTING.md) — failure modes for both transports
+- [KNOWN_ISSUES.md](KNOWN_ISSUES.md) — current limitations

--- a/docs/TRANSPORTS.md
+++ b/docs/TRANSPORTS.md
@@ -7,7 +7,7 @@ Conduit 2.0 supports two transports for publishing ROS 2 messages. This page hel
 | Your ROS 2 setup | Recommended transport |
 |------------------|-----------------------|
 | Uses `rmw_zenoh_cpp` | **Zenoh** |
-| Uses `rmw_cyclonedds_cpp` (default on Jazzy/Humble) | **DDS** |
+| Uses `rmw_cyclonedds_cpp` (default on Humble; opt-in on Jazzy/Kilted/Rolling) | **DDS** |
 | Needs to cross subnets / WAN | **Zenoh** (run a router with a public IP) |
 | Same-LAN, no bridge infrastructure | **DDS** |
 | Corporate network blocking multicast | **Zenoh** (TCP) |


### PR DESCRIPTION
## Summary

- New **docs/TRANSPORTS.md**: Zenoh vs DDS side-by-side comparison, network requirements, and when-to-switch guidance.
- **README.md**: transport matrix, per-transport quick start (Zenoh and DDS), Docker section split into Zenoh and DDS subsections, /conduit/* topic examples, 0-232 domain range.
- **PLATFORM_NOTES.md**: document iOS DDS constraints (en0 binding requirement, multicast / AP isolation, LAN-only).

## Phase

This is **Phase 3 of 4** in the Conduit Support 2.0 documentation update.
- Phase 1 (#11): docs/FAQ.md
- Phase 2 (#12): docs/TROUBLESHOOTING.md, docs/KNOWN_ISSUES.md
- Phase 4 (upcoming): Docker DDS environment (Dockerfile.dds, compose-dds.yml)

## Notes

- README references `docker/compose-dds.yml`; that file is added in the Phase 4 PR. The link is forward-looking on purpose.
- The TRANSPORTS.md link from FAQ.md (Phase 1) now resolves once both PRs are merged.

## Test plan

- [x] grep -nE "/ios/|0-255" README.md docs/PLATFORM_NOTES.md docs/TRANSPORTS.md returns empty
- [ ] Visual review of new sections renders correctly on GitHub