### PR TITLE
docker: CycloneDDS test environment for Conduit 2.0 DDS transport

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,1 +1,0 @@
-ROS_DOMAIN_ID=0

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,4 +1,4 @@
-# ROS 2 Domain ID (0-255)
-# Must match the domain ID configured in the iOS app
+# ROS 2 Domain ID (0-232)
+# Must match the domain ID configured in the Conduit iOS app
 # Default: 0
 ROS_DOMAIN_ID=0

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,4 +1,4 @@
 # ROS 2 Domain ID (0-232)
-# Must match the domain ID configured in the Conduit iOS app
+# Must match the domain ID configured in the Conduit iOS/macOS app
 # Default: 0
 ROS_DOMAIN_ID=0

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -5,3 +5,6 @@ test_results.md
 # Temporary files
 *.tmp
 *.backup
+
+# Local environment overrides (user-specific)
+.env

--- a/docker/Dockerfile.dds
+++ b/docker/Dockerfile.dds
@@ -1,0 +1,72 @@
+# Dockerfile for ROS 2 with rmw_cyclonedds_cpp (DDS transport)
+# Purpose: Test Conduit DDS transport by running a ROS 2 subscriber that
+# discovers and echoes topics from the iOS app over CycloneDDS.
+#
+# Build args:
+#   ROS_DISTRO: humble | jazzy | kilted | rolling (default: jazzy)
+#
+# Usage:
+#   docker build -f Dockerfile.dds --build-arg ROS_DISTRO=jazzy -t ros-jazzy-dds .
+#
+# NOTE: Run with --network host (Linux only). On macOS Docker Desktop,
+# host networking is not fully supported — use a native or VM ROS 2 install.
+
+ARG ROS_DISTRO=jazzy
+FROM ros:${ROS_DISTRO}
+
+ARG ROS_DISTRO
+ENV DEBIAN_FRONTEND=noninteractive
+ENV ROS_DISTRO=${ROS_DISTRO}
+
+RUN apt-get update && apt-get install -y \
+    ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
+    ros-${ROS_DISTRO}-demo-nodes-cpp \
+    ros-${ROS_DISTRO}-point-cloud-interfaces \
+    iproute2 \
+    iputils-ping \
+    net-tools \
+    vim \
+    && rm -rf /var/lib/apt/lists/*
+
+# Optional: audio_common_msgs from source (for /conduit/audio)
+WORKDIR /ros2_ws/src
+RUN git clone --branch ros2 --depth 1 \
+    https://github.com/ros-drivers/audio_common.git /tmp/audio_common && \
+    cp -r /tmp/audio_common/audio_common_msgs /ros2_ws/src/ && \
+    rm -rf /tmp/audio_common
+WORKDIR /ros2_ws
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh && \
+    colcon build --packages-select audio_common_msgs
+
+RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> /root/.bashrc && \
+    echo "source /ros2_ws/install/setup.bash" >> /root/.bashrc && \
+    echo "export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp" >> /root/.bashrc
+
+ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+
+RUN echo '#!/bin/bash\n\
+set -e\n\
+source /opt/ros/${ROS_DISTRO}/setup.bash\n\
+source /ros2_ws/install/setup.bash\n\
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp\n\
+echo ""\n\
+echo "========================================"\n\
+echo "ROS 2 ${ROS_DISTRO^} + rmw_cyclonedds_cpp Container"\n\
+echo "========================================"\n\
+echo "ROS_DISTRO: ${ROS_DISTRO}"\n\
+echo "RMW_IMPLEMENTATION: $RMW_IMPLEMENTATION"\n\
+echo "ROS_DOMAIN_ID: ${ROS_DOMAIN_ID:-0}"\n\
+echo "CYCLONEDDS_URI: ${CYCLONEDDS_URI:-<unset>}"\n\
+echo ""\n\
+echo "Host network interfaces:"\n\
+ip -4 -o addr show 2>/dev/null | awk "{print \"  \" \$2, \$4}"\n\
+echo ""\n\
+echo "Container ready. Run: ros2 topic list"\n\
+echo ""\n\
+exec sleep infinity\n\
+' > /usr/local/bin/start-dds.sh && \
+    chmod +x /usr/local/bin/start-dds.sh
+
+WORKDIR /ros2_ws
+
+CMD ["/usr/local/bin/start-dds.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,15 @@
-# Docker Testing Environment for iOS ROS 2 IMU Publisher
+# Docker Test Environments for Conduit
 
-This directory contains Docker configuration for testing the iOS ROS 2 IMU publisher with ROS 2 Jazzy and Humble using rmw_zenoh_cpp.
+Two separate Docker environments are provided, one per transport:
+
+| Environment | Transport | Use case |
+|-------------|-----------|----------|
+| `docker-compose.yml` (Zenoh) | `rmw_zenoh_cpp` | Test Conduit with Zenoh router; works on macOS and Linux. |
+| `compose-dds.yml` (DDS) | `rmw_cyclonedds_cpp` | Test Conduit with DDS subscriber; **Linux hosts only** (Docker Desktop on macOS does not support host networking). |
+
+Choose the one that matches your Conduit app's Transport setting. See [../docs/TRANSPORTS.md](../docs/TRANSPORTS.md) if you haven't decided yet.
+
+---
 
 ## Overview
 
@@ -111,7 +120,7 @@ docker compose up ros-humble -d   # or ros-jazzy
 
 #### Configuring ROS_DOMAIN_ID
 
-The Docker container supports configurable ROS 2 domain ID (0-255). The domain ID must match between the container and iOS app.
+The Docker container supports configurable ROS 2 domain ID (0-232). The domain ID must match between the container and iOS app.
 
 **Method 1: Using .env file (recommended for persistent configuration)**
 ```bash
@@ -142,7 +151,7 @@ docker compose up ros-jazzy -d
 
 **Important:**
 - Domain ID must match between Docker container and iOS app
-- Valid range: 0-255
+- Valid range: 0-232
 - Default is 0 if not specified
 - Topics will only be visible when domain IDs match on both sides
 
@@ -231,7 +240,7 @@ orientation:
 
 ```bash
 # Terminal 3: Check rate
-docker exec -it ros_jazzy_zenoh bash -c "source /opt/ros/jazzy/setup.bash && source /ros2_ws/install/setup.bash && export RMW_IMPLEMENTATION=rmw_zenoh_cpp && ros2 topic hz /ios/imu"
+docker exec -it ros_jazzy_zenoh bash -c "source /opt/ros/jazzy/setup.bash && source /ros2_ws/install/setup.bash && export RMW_IMPLEMENTATION=rmw_zenoh_cpp && ros2 topic hz /conduit/imu"
 ```
 
 **Expected:** `average rate: 100.000`
@@ -299,10 +308,10 @@ Once inside the container:
 ```bash
 # Environment is already set up
 ros2 topic list
-ros2 topic echo /ios/imu
-ros2 topic hz /ios/imu
-ros2 topic info /ios/imu -v
-ros2 topic bw /ios/imu
+ros2 topic echo /conduit/imu
+ros2 topic hz /conduit/imu
+ros2 topic info /conduit/imu -v
+ros2 topic bw /conduit/imu
 ```
 
 ## Network Configuration
@@ -424,12 +433,12 @@ open -a Docker
    ros2 topic list
    ```
 
-**Important:** ROS 2 uses domain IDs for network isolation. Topics will only be visible when both publisher (iOS app) and subscriber (Docker container) use the same domain ID (0-255).
+**Important:** ROS 2 uses domain IDs for network isolation. Topics will only be visible when both publisher (iOS app) and subscriber (Docker container) use the same domain ID (0-232).
 
 ### Problem: No Messages on Topic
 
 **Symptoms:**
-- `ros2 topic echo /ios/imu` shows nothing
+- `ros2 topic echo /conduit/imu` shows nothing
 - App says "Publishing" but no data
 
 **Solutions:**
@@ -491,8 +500,8 @@ docker compose build --no-cache
 - [ ] iOS Simulator app built and running
 - [ ] App shows "Running in simulator - using mock data"
 - [ ] App shows "Publishing" status
-- [ ] `ros2 topic list` shows `/ios/imu`
-- [ ] `ros2 topic echo /ios/imu` receives messages
+- [ ] `ros2 topic list` shows `/conduit/imu`
+- [ ] `ros2 topic echo /conduit/imu` receives messages
 - [ ] Messages have correct format
 - [ ] Publishing rate is ~100 Hz
 - [ ] Sequence numbers are monotonic
@@ -580,6 +589,59 @@ After successful Docker testing:
 2. Test with native ROS 2 installation (non-Docker)
 3. Deploy to production environment
 4. Implement monitoring and alerts
+
+## DDS Environment
+
+### Prerequisites
+
+- **Linux host** — macOS Docker Desktop does not support true host networking and will not receive DDS traffic from iOS devices. Use a Linux box, a Parallels/UTM VM, or install CycloneDDS natively on macOS instead.
+- iOS device and Linux host on the same LAN subnet.
+
+### Build & Start
+
+```bash
+cd support/docker
+
+# Default domain (0)
+docker compose -f compose-dds.yml up ros-jazzy-dds -d
+
+# Custom domain
+ROS_DOMAIN_ID=5 docker compose -f compose-dds.yml up ros-jazzy-dds -d
+```
+
+The container runs with `network_mode: host` and stays idle (`sleep infinity`) — exec in to run subscribers:
+
+```bash
+docker exec -it ros_jazzy_dds bash
+# Inside the container:
+source /opt/ros/jazzy/setup.bash
+source /ros2_ws/install/setup.bash
+ros2 topic list
+ros2 topic echo /conduit/imu --qos-reliability best_effort
+ros2 topic hz /conduit/imu
+```
+
+### Unicast Discovery
+
+If multicast is blocked (corporate/consumer WiFi):
+
+1. Edit `cyclonedds.xml` and uncomment the `<Peers>` block; add the iOS device IP.
+2. Restart the container: `docker compose -f compose-dds.yml restart`.
+3. In Conduit Settings → Transport → DDS → Discovery Mode: **Unicast** and add the host IP to Unicast Peers.
+
+### Configure Conduit App (DDS)
+
+- Settings → Transport: **DDS**
+- Discovery Mode: **Hybrid** (recommended)
+- Unicast Peers: add the Linux host IP
+- Network Interface: **en0** (do not use auto)
+- Domain ID: match `ROS_DOMAIN_ID`
+
+### Troubleshooting DDS in Docker
+
+- **No topics visible:** Confirm `--network host` is in effect (`docker inspect ros_jazzy_dds | grep NetworkMode`) and the host firewall allows UDP on `7400 + 250 * domain_id` and adjacent ports.
+- **Topics visible but no data:** Use `--qos-reliability best_effort` on the subscriber.
+- **Works from host but not from iOS:** Check AP isolation on your WiFi; try Unicast mode.
 
 ## Reference
 

--- a/docker/compose-dds.yml
+++ b/docker/compose-dds.yml
@@ -1,0 +1,55 @@
+# Docker Compose for ROS 2 + rmw_cyclonedds_cpp testing
+#
+# Linux hosts only. macOS Docker Desktop does not provide true host
+# networking and will not receive DDS traffic from external iOS devices.
+#
+# Usage:
+#   Start: docker compose -f compose-dds.yml up ros-jazzy-dds -d
+#   Stop:  docker compose -f compose-dds.yml down
+#
+# Environment Variables:
+#   ROS_DOMAIN_ID  - ROS 2 domain ID (0-232, default: 0)
+#   CYCLONEDDS_URI - Optional path to a CycloneDDS XML config mounted into
+#                    the container. Defaults to /etc/cyclonedds/cyclonedds.xml
+#                    mounted from ./cyclonedds.xml.
+
+services:
+  ros-jazzy-dds:
+    build:
+      context: .
+      dockerfile: Dockerfile.dds
+      args:
+        ROS_DISTRO: jazzy
+    container_name: ros_jazzy_dds
+    hostname: ros-jazzy-dds
+    network_mode: host
+    environment:
+      - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-0}
+      - ROS_DISTRO=jazzy
+      - CYCLONEDDS_URI=file:///etc/cyclonedds/cyclonedds.xml
+    volumes:
+      - ./cyclonedds.xml:/etc/cyclonedds/cyclonedds.xml:ro
+    stdin_open: true
+    tty: true
+    restart: unless-stopped
+
+  ros-humble-dds:
+    build:
+      context: .
+      dockerfile: Dockerfile.dds
+      args:
+        ROS_DISTRO: humble
+    container_name: ros_humble_dds
+    hostname: ros-humble-dds
+    network_mode: host
+    environment:
+      - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-0}
+      - ROS_DISTRO=humble
+      - CYCLONEDDS_URI=file:///etc/cyclonedds/cyclonedds.xml
+    volumes:
+      - ./cyclonedds.xml:/etc/cyclonedds/cyclonedds.xml:ro
+    stdin_open: true
+    tty: true
+    restart: unless-stopped

--- a/docker/cyclonedds.xml
+++ b/docker/cyclonedds.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CycloneDDS xmlns="https://cdds.io/config"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="https://cdds.io/config https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/master/etc/cyclonedds.xsd">
+  <Domain id="any">
+    <General>
+      <!-- Uncomment and set to the interface that reaches your iOS device.
+           On Linux servers this is usually eth0, enp0s5, wlan0, etc.
+           On a Parallels VM it's typically enp0s5. -->
+      <!-- <Interfaces><NetworkInterface name="eth0"/></Interfaces> -->
+    </General>
+    <Discovery>
+      <!-- Uncomment and add the iOS device IP for unicast discovery.
+           Required if multicast is blocked on your network. -->
+      <!--
+      <Peers>
+        <Peer address="192.168.1.50"/>
+      </Peers>
+      -->
+    </Discovery>
+  </Domain>
+</CycloneDDS>


### PR DESCRIPTION
## Summary

- New **Dockerfile.dds**: ROS 2 + rmw_cyclonedds_cpp + demo-nodes-cpp + audio_common_msgs (built from source).
- New **compose-dds.yml**: host-networked services for Jazzy and Humble; mounts cyclonedds.xml as CYCLONEDDS_URI.
- New **cyclonedds.xml**: template with commented Peers block for unicast discovery.
- **docker/README.md**: split into Zenoh and DDS sections; documents the macOS Docker Desktop host-networking limitation; updated /conduit/* topic examples and 0-232 domain range.
- **.env.example**: document 0-232 range.
- Untrack docker/.env (user-local overrides should not be committed). Existing .env files on contributor machines are preserved on disk.

## Phase

This is **Phase 4 of 4** (final) in the Conduit Support 2.0 documentation update.
- Phase 1 (#11): docs/FAQ.md
- Phase 2 (#12): docs/TROUBLESHOOTING.md, docs/KNOWN_ISSUES.md
- Phase 3 (#13): README.md, docs/TRANSPORTS.md, docs/PLATFORM_NOTES.md
- Phase 4 (this PR): Docker DDS environment

After all 4 PRs merge, the support submodule SHA will be bumped in the main Conduit repo to point to the new state.

## Manual verification (Linux host required)

```bash
cd support/docker
ROS_DOMAIN_ID=0 docker compose -f compose-dds.yml up ros-jazzy-dds -d
docker exec -it ros_jazzy_dds bash -c \
  "source /opt/ros/jazzy/setup.bash && ros2 topic list"
```

(Not verified by author — requires Linux host with iOS device on the same LAN.)

## Test plan

- [x] grep -nE "/ios/|0-255" docker/README.md docker/.env.example returns empty
- [x] git ls-files docker/.env returns empty (now untracked)
- [x] docker/.env preserved on disk with user's value
- [ ] Build verification on Linux: `docker compose -f compose-dds.yml build ros-jazzy-dds`