### PR TITLE
docs(platform): document LiDAR / front-camera exclusivity on iOS

### DIFF
--- a/docs/PLATFORM_NOTES.md
+++ b/docs/PLATFORM_NOTES.md
@@ -28,7 +28,7 @@ Information about sensor availability and limitations on different Apple platfor
 **LiDAR and front camera are mutually exclusive on iOS:**
 - LiDAR uses ARKit's `ARSession`, which takes exclusive control of the rear camera system to produce depth frames.
 - The front camera uses `AVCaptureSession`. iOS only permits one `AVCaptureSession` at a time, and `ARSession` already owns the rear pipeline, so LiDAR and front camera cannot run simultaneously.
-- Back cameras are supported together with LiDAR because their frames come from the same `ARSession`. Only the combination **LiDAR + front camera** is blocked.
+- The rear camera is supported together with LiDAR because its frames come from the same `ARSession`. Only the combination **LiDAR + front camera** is blocked.
 - When you toggle one on, Conduit automatically disables the other to avoid an OS-level session conflict that would otherwise stop capture for both.
 
 **Background Mode**:

--- a/docs/PLATFORM_NOTES.md
+++ b/docs/PLATFORM_NOTES.md
@@ -25,6 +25,12 @@ Information about sensor availability and limitations on different Apple platfor
 - iPhone: 12 Pro, 13 Pro, 14 Pro, 15 Pro series
 - iPad: Pro 11" (2020+), Pro 12.9" (2020+)
 
+**LiDAR and front camera are mutually exclusive on iOS:**
+- LiDAR uses ARKit's `ARSession`, which takes exclusive control of the rear camera system to produce depth frames.
+- The front camera uses `AVCaptureSession`. iOS only permits one `AVCaptureSession` at a time, and `ARSession` already owns the rear pipeline, so LiDAR and front camera cannot run simultaneously.
+- Back cameras are supported together with LiDAR because their frames come from the same `ARSession`. Only the combination **LiDAR + front camera** is blocked.
+- When you toggle one on, Conduit automatically disables the other to avoid an OS-level session conflict that would otherwise stop capture for both.
+
 **Background Mode**:
 - ✅ IMU, Magnetometer, Barometer, Battery, Thermal
 - ✅ GPS (foreground only - "When In Use" permission)

--- a/docs/PLATFORM_NOTES.md
+++ b/docs/PLATFORM_NOTES.md
@@ -27,9 +27,9 @@ Information about sensor availability and limitations on different Apple platfor
 
 **LiDAR and front camera are mutually exclusive on iOS:**
 - LiDAR uses ARKit's `ARSession`, which takes exclusive control of the rear camera system to produce depth frames.
-- The front camera uses `AVCaptureSession`. iOS only permits one `AVCaptureSession` at a time, and `ARSession` already owns the rear pipeline, so LiDAR and front camera cannot run simultaneously.
-- The rear camera is supported together with LiDAR because its frames come from the same `ARSession`. Only the combination **LiDAR + front camera** is blocked.
-- When you toggle one on, Conduit automatically disables the other to avoid an OS-level session conflict that would otherwise stop capture for both.
+- The front camera uses `AVCaptureSession`. While iOS can support multiple capture sessions in some configurations, `ARSession` owns the rear camera/depth pipeline here, so this app cannot run LiDAR and a separate front-camera capture session simultaneously.
+- Back cameras are supported together with LiDAR because their frames come from the same `ARSession`. Only the combination **LiDAR + front camera** is blocked.
+- When you toggle one on, Conduit automatically disables the other to avoid this ARKit/camera-device exclusivity conflict, which would otherwise stop capture for both.
 
 **Background Mode**:
 - ✅ IMU, Magnetometer, Barometer, Battery, Thermal


### PR DESCRIPTION
Adds an explicit note to \`docs/PLATFORM_NOTES.md\` explaining why iOS blocks the LiDAR + front-camera combination and clarifying that LiDAR + back camera is supported.

## Why

Recurring question from the issue tracker — most recently https://github.com/youtalk/conduit-support/issues/8. The behavior is intentional (ARKit \`ARSession\` has exclusive control of the rear camera pipeline; \`AVCaptureSession\` can only have one active instance; back-camera frames flow through \`ARSession\` so they coexist with LiDAR). Documenting it avoids users thinking the app has a bug when it auto-disables the other sensor.

## Change

- \`docs/PLATFORM_NOTES.md\`: new \"LiDAR and front camera are mutually exclusive on iOS\" bullet block under the iOS sensor table.

No other content changed.