### PR TITLE
docs: refresh README, add PRIVACY.md, surface swift-ros2 + traction

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -26,7 +26,7 @@ The app may access, transmit, and (when MCAP recording is enabled) write the fol
 
 - All sensor data collection is **opt-in**. Sensors are disabled by default.
 - Data is transmitted **only to the Zenoh router or DDS subscriber you configure** (typically on your local network — under your control, not ours).
-- **No sensor data is sent to our servers** or any third-party servers. Conduit operates no backend; the app is a wire-level publisher only.
+- **No sensor data is sent to our servers** or any third-party servers. Conduit does not operate a backend that receives, stores, or relays sensor streams; the app is a wire-level publisher only. (Anonymous **app-usage analytics** events are a separate path — see the Analytics Data section below.)
 - **Background GPS tracking is not supported** due to privacy constraints. Location data is only collected while the app is active.
 
 ### Analytics Data
@@ -60,7 +60,7 @@ This data is used solely to improve app functionality and user experience.
 - **MCAP recordings (opt-in)**: When you start a recording, the app writes the same sensor messages to a local `.mcap` file in the app's Documents directory. Recordings stay on-device and are never uploaded by Conduit. You can browse, delete, or share them via the iOS / macOS share sheet (e.g. Files, AirDrop, mail) — Conduit hands the file off to the system from there.
 - **Configuration settings**: Stored locally on your device using iOS Keychain and UserDefaults. The 16-byte ROS 2 publisher GID is generated once and persisted to Keychain so the same publisher identity survives app launches.
 - **Network transmission**: Data is sent over your local network to the Zenoh router or DDS subscriber you configure.
-- **Firebase Analytics**: Collects anonymous usage statistics. Subject to [Google's Privacy Policy](https://policies.google.com/privacy). You can opt out by disabling analytics in iOS Settings → Privacy → Analytics & Improvements.
+- **Firebase Analytics**: Collects anonymous usage statistics. Subject to [Google's Privacy Policy](https://policies.google.com/privacy). You can opt out at any time from inside the app — **Settings → Privacy → Send Usage Statistics** — which calls Firebase's `setAnalyticsCollectionEnabled(false)` and persists the choice across launches.
 
 ## Permissions
 
@@ -80,7 +80,7 @@ You have the right to:
 
 - **Control sensor access**: Enable/disable any sensor at any time
 - **Delete app data**: Uninstall the app to remove all local data
-- **Opt out of analytics**: Disable analytics in iOS Settings
+- **Opt out of analytics**: Toggle off **Settings → Privacy → Send Usage Statistics** inside the app at any time
 
 ## In-App Purchases
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-**Last Updated: April 24, 2026**
+**Last Updated: December 20, 2025**
 
 Conduit is a developer tool that publishes sensor data from Apple devices (iOS / iPadOS / macOS / visionOS) to ROS 2 (Robot Operating System 2) networks. It is built on top of the open-source [swift-ros2](https://github.com/youtalk/swift-ros2) Swift client library, which speaks the ROS 2 wire formats directly over Zenoh or DDS — without any Conduit-operated cloud service in between. This privacy policy explains what data the app collects, how it's used, and your rights.
 
@@ -10,7 +10,7 @@ Conduit is a developer tool that publishes sensor data from Apple devices (iOS /
 
 ### Sensor Data (User-Controlled)
 
-The app may access and transmit the following sensor data **only when you explicitly enable each sensor**:
+The app may access, transmit, and (when MCAP recording is enabled) write the following sensor data to local files **only when you explicitly enable each sensor**:
 
 - **Motion Data**: Accelerometer, gyroscope, magnetometer readings (IMU)
 - **Location Data**: GPS coordinates (only while app is in use)
@@ -56,7 +56,8 @@ This data is used solely to improve app functionality and user experience.
 
 ## Data Storage and Security
 
-- **Sensor data**: Not stored by the app. Transmitted in real-time to your ROS 2 system.
+- **Sensor data (live publishing)**: Not stored by the app. Transmitted in real-time to your ROS 2 system.
+- **MCAP recordings (opt-in)**: When you start a recording, the app writes the same sensor messages to a local `.mcap` file in the app's Documents directory. Recordings stay on-device and are never uploaded by Conduit. You can browse, delete, or share them via the iOS / macOS share sheet (e.g. Files, AirDrop, mail) — Conduit hands the file off to the system from there.
 - **Configuration settings**: Stored locally on your device using iOS Keychain and UserDefaults. The 16-byte ROS 2 publisher GID is generated once and persisted to Keychain so the same publisher identity survives app launches.
 - **Network transmission**: Data is sent over your local network to the Zenoh router or DDS subscriber you configure.
 - **Firebase Analytics**: Collects anonymous usage statistics. Subject to [Google's Privacy Policy](https://policies.google.com/privacy). You can opt out by disabling analytics in iOS Settings → Privacy → Analytics & Improvements.
@@ -81,9 +82,14 @@ You have the right to:
 - **Delete app data**: Uninstall the app to remove all local data
 - **Opt out of analytics**: Disable analytics in iOS Settings
 
+## In-App Purchases
+
+Some advanced features (Camera, LiDAR, Game Controller, Background publishing, MCAP Recording) are gated behind one-time In-App Purchases via Apple's StoreKit. Purchase processing, receipt validation, and refund handling are performed by Apple — Conduit only sees the resulting entitlement state and does not collect, store, or transmit payment information. See Apple's [App Store & Privacy](https://www.apple.com/legal/privacy/data/en/app-store/) policy for details.
+
 ## Data Retention
 
-- **Sensor data**: Not retained by the app (transmitted in real-time)
+- **Sensor data (live publishing)**: Not retained by the app (transmitted in real-time)
+- **MCAP recordings**: Kept on-device until you delete them from within Conduit, delete them from Files, or uninstall the app. Conduit never uploads them.
 - **Configuration data**: Stored until app is uninstalled
 - **Analytics data**: Retained by Firebase per [their retention policy](https://support.google.com/firebase/answer/7029846)
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,101 @@
+# Privacy Policy
+
+**Last Updated: April 24, 2026**
+
+Conduit is a developer tool that publishes sensor data from Apple devices (iOS / iPadOS / macOS / visionOS) to ROS 2 (Robot Operating System 2) networks. It is built on top of the open-source [swift-ros2](https://github.com/youtalk/swift-ros2) Swift client library, which speaks the ROS 2 wire formats directly over Zenoh or DDS — without any Conduit-operated cloud service in between. This privacy policy explains what data the app collects, how it's used, and your rights.
+
+**Developer**: Yutaka Kondo (youtalk) · [LinkedIn](https://www.linkedin.com/in/youtalk) · [Website](https://youtalk.jp)
+
+## Data Collection
+
+### Sensor Data (User-Controlled)
+
+The app may access and transmit the following sensor data **only when you explicitly enable each sensor**:
+
+- **Motion Data**: Accelerometer, gyroscope, magnetometer readings (IMU)
+- **Location Data**: GPS coordinates (only while app is in use)
+- **Camera Data**: Images from device cameras
+- **Environmental Data**: Barometer, ambient light sensor
+- **Device State**: Battery level, thermal state
+- **LiDAR Data**: Depth sensing (on supported devices)
+- **Game Controller Input**: Button and joystick data
+- **Audio Data**: Microphone samples (when the Microphone sensor is enabled)
+- **Proximity Data**: Front-facing proximity sensor reading
+
+**Important Notes**:
+
+- All sensor data collection is **opt-in**. Sensors are disabled by default.
+- Data is transmitted **only to the Zenoh router or DDS subscriber you configure** (typically on your local network — under your control, not ours).
+- **No sensor data is sent to our servers** or any third-party servers. Conduit operates no backend; the app is a wire-level publisher only.
+- **Background GPS tracking is not supported** due to privacy constraints. Location data is only collected while the app is active.
+
+### Analytics Data
+
+The app uses Firebase Analytics to collect:
+
+- **Device Information**: Device model, OS version
+- **App Usage**: Feature usage, error occurrences
+- **Anonymous Identifiers**: Non-personal device identifiers
+
+This data is used solely to improve app functionality and user experience.
+
+## How Data Is Used
+
+**Sensor Data:**
+
+- Transmitted directly to your configured ROS 2 system over Zenoh (`rmw_zenoh_cpp`) or DDS (`rmw_cyclonedds_cpp`)
+- Used for robotics development, research, and testing
+- Never stored on our servers
+- Never shared with third parties
+
+**Analytics Data:**
+
+- Used to identify bugs and improve app performance
+- Aggregated and anonymized
+- Processed by Google Firebase Analytics (see their [privacy policy](https://firebase.google.com/support/privacy))
+
+## Data Storage and Security
+
+- **Sensor data**: Not stored by the app. Transmitted in real-time to your ROS 2 system.
+- **Configuration settings**: Stored locally on your device using iOS Keychain and UserDefaults. The 16-byte ROS 2 publisher GID is generated once and persisted to Keychain so the same publisher identity survives app launches.
+- **Network transmission**: Data is sent over your local network to the Zenoh router or DDS subscriber you configure.
+- **Firebase Analytics**: Collects anonymous usage statistics. Subject to [Google's Privacy Policy](https://policies.google.com/privacy). You can opt out by disabling analytics in iOS Settings → Privacy → Analytics & Improvements.
+
+## Permissions
+
+| Permission | Purpose | Required |
+|---|---|---|
+| Camera | Publish camera images to ROS 2 | Optional |
+| Microphone | Publish audio samples to ROS 2 | Optional |
+| Location (When In Use) | Publish GPS data to ROS 2 | Optional |
+| Motion & Fitness | Access IMU sensors | Optional |
+| Local Network | Connect to Zenoh router or DDS subscriber on your network | Required |
+
+**Note**: All permissions except Local Network are optional. You can selectively enable only the sensors you need.
+
+## Your Rights
+
+You have the right to:
+
+- **Control sensor access**: Enable/disable any sensor at any time
+- **Delete app data**: Uninstall the app to remove all local data
+- **Opt out of analytics**: Disable analytics in iOS Settings
+
+## Data Retention
+
+- **Sensor data**: Not retained by the app (transmitted in real-time)
+- **Configuration data**: Stored until app is uninstalled
+- **Analytics data**: Retained by Firebase per [their retention policy](https://support.google.com/firebase/answer/7029846)
+
+## Policy Updates
+
+We may update this privacy policy from time to time. Changes will be posted on this page with an updated "Last Updated" date.
+
+## Contact
+
+For questions or concerns:
+
+- **LinkedIn**: https://www.linkedin.com/in/youtalk
+- **Website**: https://youtalk.jp
+
+**Note**: This app is designed for developers and researchers. It is not intended for children under 13.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -26,7 +26,7 @@ The app may access, transmit, and (when MCAP recording is enabled) write the fol
 
 - All sensor data collection is **opt-in**. Sensors are disabled by default.
 - Data is transmitted **only to the Zenoh router or DDS subscriber you configure** (typically on your local network — under your control, not ours).
-- **No sensor data is sent to our servers** or any third-party servers. Conduit does not operate a backend that receives, stores, or relays sensor streams; the app is a wire-level publisher only. (Anonymous **app-usage analytics** events are a separate path — see the Analytics Data section below.)
+- **No sensor data is sent to our servers** or any third-party servers. Conduit operates no backend; the app is a wire-level publisher only.
 - **Background GPS tracking is not supported** due to privacy constraints. Location data is only collected while the app is active.
 
 ### Analytics Data
@@ -60,7 +60,7 @@ This data is used solely to improve app functionality and user experience.
 - **MCAP recordings (opt-in)**: When you start a recording, the app writes the same sensor messages to a local `.mcap` file in the app's Documents directory. Recordings stay on-device and are never uploaded by Conduit. You can browse, delete, or share them via the iOS / macOS share sheet (e.g. Files, AirDrop, mail) — Conduit hands the file off to the system from there.
 - **Configuration settings**: Stored locally on your device using iOS Keychain and UserDefaults. The 16-byte ROS 2 publisher GID is generated once and persisted to Keychain so the same publisher identity survives app launches.
 - **Network transmission**: Data is sent over your local network to the Zenoh router or DDS subscriber you configure.
-- **Firebase Analytics**: Collects anonymous usage statistics. Subject to [Google's Privacy Policy](https://policies.google.com/privacy). You can opt out at any time from inside the app — **Settings → Privacy → Send Usage Statistics** — which calls Firebase's `setAnalyticsCollectionEnabled(false)` and persists the choice across launches.
+- **Firebase Analytics**: Collects anonymous usage statistics. Subject to [Google's Privacy Policy](https://policies.google.com/privacy). You can opt out by disabling analytics in iOS Settings → Privacy → Analytics & Improvements.
 
 ## Permissions
 
@@ -80,7 +80,7 @@ You have the right to:
 
 - **Control sensor access**: Enable/disable any sensor at any time
 - **Delete app data**: Uninstall the app to remove all local data
-- **Opt out of analytics**: Toggle off **Settings → Privacy → Send Usage Statistics** inside the app at any time
+- **Opt out of analytics**: Disable analytics in iOS Settings
 
 ## In-App Purchases
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,23 @@
 <div align="center">
 
-<img src="images/app_icon.png" width="128" height="128" alt="Conduit App Icon">
+<a href="https://apps.apple.com/app/id6757171237">
+<img src="images/app_icon.png" width="128" height="128" alt="Download Conduit on the App Store">
+</a>
 
 # Conduit
 
 **Transform your Apple devices into ROS 2 sensor publishers**
 
-Stream real-time sensor data directly to your robotics system via **Zenoh** or **DDS** — pick the transport that matches your ROS 2 setup.
+Stream real-time sensor data directly to your robotics system via **Zenoh** or **DDS** — pick the transport that matches your ROS 2 setup. No bridge, no `rcl` / `rclcpp`, no CMake on a non-Linux host.
 
-[![Download on App Store](https://img.shields.io/badge/Download-App%20Store-blue?style=for-the-badge&logo=apple)](https://apps.apple.com/jp/app/conduit-powered-by-ros/id6757171237?l=en-US)
-[![ROS 2](https://img.shields.io/badge/ROS%202-Humble%20|%20Jazzy%20|%20Kilted%20|%20Rolling-green?style=for-the-badge)](https://ros.org)
+<a href="https://apps.apple.com/app/id6757171237">
+<img src="images/app_icon.png" width="180" alt="Download Conduit on the App Store">
+</a>
+
+[![ROS 2](https://img.shields.io/badge/ROS%202-Humble%20|%20Jazzy%20|%20Kilted%20|%20Rolling-22314E?style=for-the-badge)](https://docs.ros.org)
+[![Built on swift-ros2](https://img.shields.io/badge/Built%20on-swift--ros2%200.6.0-orange?style=for-the-badge&logo=swift)](https://github.com/youtalk/swift-ros2)
+
+> Used cumulatively by **10,000+ ROS 2 developers worldwide** — peaked at **#4 in the App Store's Developer Tools category** (Japan) since January 2026.
 
 </div>
 
@@ -45,13 +53,23 @@ Stream real-time sensor data directly to your robotics system via **Zenoh** or *
 
 ---
 
+## Built on swift-ros2
+
+All ROS 2 wire work — Zenoh / DDS FFI, XCDR v1 codec, Humble/Jazzy/Kilted/Rolling wire codecs, the publisher/subscription API — is delegated to [**swift-ros2**](https://github.com/youtalk/swift-ros2), a native Swift client library for ROS 2 that was extracted from Conduit and now ships independently.
+
+swift-ros2 covers every consumer device OS that runs Swift: **iOS / iPadOS / macOS / Mac Catalyst / visionOS** (pre-built xcframeworks via SwiftPM), plus **Linux** (Ubuntu 22.04 / 24.04, x86_64 + aarch64), **Windows** (x86_64), and **Android** (arm64-v8a + x86_64) via source build. By worldwide market share, that's roughly 90%+ of identifiable consumer devices — phones, tablets, laptops, headsets, SBCs — all able to publish and subscribe through the same SwiftPM-resolvable package.
+
+If you want to wire your own Swift app into a ROS 2 graph (rather than use Conduit as a black-box sensor publisher), [swift-ros2](https://github.com/youtalk/swift-ros2) is the SDK underneath this app.
+
+---
+
 ## Features
 
 | Platform | Sensors |
 |----------|---------|
-| iOS/iPadOS 16+ | All 12 sensors |
+| iOS / iPadOS 16+ | All 12 sensors |
 | visionOS 1+ | Camera, IMU, Game Controller |
-| macOS 13+ | Camera, Battery, Game Controller |
+| macOS 13+ (Mac Catalyst) | Camera, Battery, Game Controller |
 
 ### Transports
 
@@ -132,7 +150,7 @@ See [TRANSPORTS.md](docs/TRANSPORTS.md) for a detailed comparison.
 
 ## Quick Start
 
-1. **Download** from [App Store](https://apps.apple.com/jp/app/conduit-powered-by-ros/id6757171237?l=en-US)
+1. **Download** from the [App Store](https://apps.apple.com/app/id6757171237)
 2. **Choose your transport** — see [TRANSPORTS.md](docs/TRANSPORTS.md)
 
 ### Quick Start — Zenoh
@@ -210,17 +228,18 @@ ros2 topic list
 ros2 topic echo /conduit/imu --qos-reliability best_effort
 ```
 
-See [docker/README.md](docker/README.md) for the complete Docker guide. The `compose-dds.yml` file is added in a follow-up Phase 4 PR.
+See [docker/README.md](docker/README.md) for the complete Docker guide.
 
 ---
 
 ## Documentation
 
-- [Transports](docs/TRANSPORTS.md) - Zenoh vs DDS comparison and when to use each
-- [FAQ](docs/FAQ.md) - Frequently asked questions
-- [Troubleshooting Guide](docs/TROUBLESHOOTING.md) - Common issues and solutions
-- [Platform Notes](docs/PLATFORM_NOTES.md) - Platform-specific information
-- [Known Issues](docs/KNOWN_ISSUES.md) - Current limitations and workarounds
+- [Transports](docs/TRANSPORTS.md) — Zenoh vs DDS comparison and when to use each
+- [FAQ](docs/FAQ.md) — Frequently asked questions
+- [Troubleshooting Guide](docs/TROUBLESHOOTING.md) — Common issues and solutions
+- [Platform Notes](docs/PLATFORM_NOTES.md) — Platform-specific information
+- [Known Issues](docs/KNOWN_ISSUES.md) — Current limitations and workarounds
+- [Privacy Policy](PRIVACY.md) — Data handling, sensor permissions, analytics
 
 ---
 
@@ -235,4 +254,5 @@ See [docker/README.md](docker/README.md) for the complete Docker guide. The `com
 
 - [App Website](https://www.youtalk.jp/conduit)
 - [Source Code](https://github.com/youtalk/conduit)
-- [Privacy Policy](https://www.youtalk.jp/conduit/#privacy-policy)
+- [swift-ros2 (underlying ROS 2 client library)](https://github.com/youtalk/swift-ros2)
+- [Privacy Policy](PRIVACY.md)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 **Transform your Apple devices into ROS 2 sensor publishers**
 
 Stream real-time sensor data directly to your robotics system via **Zenoh** or **DDS** — pick the transport that matches your ROS 2 setup. No bridge, no `rcl` / `rclcpp`, no CMake on a non-Linux host.
-Used cumulatively by **10,000+ ROS 2 developers worldwide** — peaked at **#4 in the App Store's Developer Tools category** (Japan) since January 2026.
+Used cumulatively by **10,000+ ROS 2 developers worldwide** — has ranked as high as **#4 in the App Store's Developer Tools category** (Japan) since January 2026.
 
 [![ROS 2](https://img.shields.io/badge/ROS%202-Humble%20|%20Jazzy%20|%20Kilted%20|%20Rolling-22314E?style=for-the-badge)](https://docs.ros.org)
 [![Built on swift-ros2](https://img.shields.io/badge/Built%20on-swift--ros2%200.6.0-orange?style=for-the-badge&logo=swift)](https://github.com/youtalk/swift-ros2)
@@ -79,7 +79,7 @@ See [TRANSPORTS.md](docs/TRANSPORTS.md) for a detailed comparison.
 
 - **Motion**: IMU (100Hz) · Magnetometer (100Hz) · GPS (1Hz) · Proximity (10Hz)
 - **Perception**: Camera (15Hz) · LiDAR (10Hz)
-- **Environment**: Barometer (10Hz) · Illuminance (10Hz) · Temperature (1Hz)
+- **Environment**: Barometer (10Hz) · Illuminance (10Hz) · Thermal (1Hz)
 - **Input**: Game Controller (50Hz) · Microphone (`audio_common_msgs/AudioData`, streaming)
 - **Status**: Battery (1Hz)
 
@@ -91,7 +91,7 @@ Same wire path as live publishing: the same XCDR v1 encoder from [swift-ros2](ht
 
 ### In-App Purchases
 
-A core slice (IMU, Magnetometer, GPS, Proximity, Barometer, Illuminance, Temperature, Battery, Microphone) ships free. Camera, LiDAR, Game Controller, Background publishing, and MCAP Recording are unlocked individually via App Store In-App Purchases.
+A core slice (IMU, Magnetometer, GPS, Proximity, Barometer, Illuminance, Thermal, Battery, Microphone, Front camera) ships free. Wide / Ultra-wide / Telephoto cameras, LiDAR, Game Controller, Background publishing, and MCAP Recording are unlocked individually via App Store In-App Purchases.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -173,11 +173,20 @@ A core slice (IMU, Magnetometer, GPS, Proximity, Barometer, Illuminance, Tempera
    source /opt/ros/jazzy/setup.bash
    export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
    export ROS_DOMAIN_ID=0  # Valid range: 0-232
+
+   # If you previously ran ros2 commands under a different RMW
+   # (e.g. rmw_zenoh_cpp), restart the cached ros2 daemon so it picks up
+   # the new RMW_IMPLEMENTATION / ROS_DOMAIN_ID / CYCLONEDDS_URI.
+   ros2 daemon stop
+   ros2 daemon start          # optional — `ros2 topic list` will autostart it
+
    ros2 topic list
    ```
 2. In the Conduit app: Settings → Transport: **DDS**, Discovery Mode: **Hybrid**, add the host IP to Unicast Peers, Network Interface: `en0`, set Domain ID to match.
 3. Enable sensors and tap Play.
 4. Verify: `ros2 topic echo /conduit/imu --qos-reliability best_effort`
+
+> **Note:** Re-run `ros2 daemon stop` any time you change `RMW_IMPLEMENTATION`, `ROS_DOMAIN_ID`, `CYCLONEDDS_URI`, or the unicast peer list — the daemon caches the first context and silently ignores later env-var changes. See [TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md#ros2-cli-shows-stale-topics-after-changing-rmw_implementation-or-cyclonedds_uri) for the full failure mode.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,18 @@ See [TRANSPORTS.md](docs/TRANSPORTS.md) for a detailed comparison.
 - **Motion**: IMU (100Hz) · Magnetometer (100Hz) · GPS (1Hz) · Proximity (10Hz)
 - **Perception**: Camera (15Hz) · LiDAR (10Hz)
 - **Environment**: Barometer (10Hz) · Illuminance (10Hz) · Temperature (1Hz)
-- **Input**: Game Controller (50Hz) · Microphone
+- **Input**: Game Controller (50Hz) · Microphone (`audio_common_msgs/AudioData`, streaming)
 - **Status**: Battery (1Hz)
+
+### MCAP Recording
+
+Capture every published topic to a local **MCAP** file with one tap, replay it later in [Foxglove](https://foxglove.dev/), `ros2 bag play`, or any MCAP-aware tool. Recordings live in the app's Documents directory and ship out via the standard share sheet (Files, AirDrop, Mail, …) — Conduit never uploads them. Schemas are written into the MCAP header automatically so the bag round-trips through any reader without external `.msg` files.
+
+Same wire path as live publishing: the same XCDR v1 encoder from [swift-ros2](https://github.com/youtalk/swift-ros2) feeds both the Zenoh / DDS publisher and the MCAP writer, so the on-disk bytes match what arrives on the ROS 2 graph.
+
+### In-App Purchases
+
+A core slice (IMU, Magnetometer, GPS, Proximity, Barometer, Illuminance, Temperature, Battery, Microphone) ships free. Camera, LiDAR, Game Controller, Background publishing, and MCAP Recording are unlocked individually via App Store In-App Purchases.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,20 +6,15 @@
 
 # Conduit
 
+</div>
+
 **Transform your Apple devices into ROS 2 sensor publishers**
 
 Stream real-time sensor data directly to your robotics system via **Zenoh** or **DDS** — pick the transport that matches your ROS 2 setup. No bridge, no `rcl` / `rclcpp`, no CMake on a non-Linux host.
-
-<a href="https://apps.apple.com/app/id6757171237">
-<img src="images/app_icon.png" width="180" alt="Download Conduit on the App Store">
-</a>
+Used cumulatively by **10,000+ ROS 2 developers worldwide** — peaked at **#4 in the App Store's Developer Tools category** (Japan) since January 2026.
 
 [![ROS 2](https://img.shields.io/badge/ROS%202-Humble%20|%20Jazzy%20|%20Kilted%20|%20Rolling-22314E?style=for-the-badge)](https://docs.ros.org)
 [![Built on swift-ros2](https://img.shields.io/badge/Built%20on-swift--ros2%200.6.0-orange?style=for-the-badge&logo=swift)](https://github.com/youtalk/swift-ros2)
-
-> Used cumulatively by **10,000+ ROS 2 developers worldwide** — peaked at **#4 in the App Store's Developer Tools category** (Japan) since January 2026.
-
-</div>
 
 ---
 
@@ -82,15 +77,11 @@ See [TRANSPORTS.md](docs/TRANSPORTS.md) for a detailed comparison.
 
 ### 12 Sensor Types
 
-**Motion**: IMU (100Hz) · Magnetometer (100Hz) · GPS (1Hz) · Proximity (10Hz)
-
-**Perception**: Camera (15Hz) · LiDAR (10Hz)
-
-**Environment**: Barometer (10Hz) · Illuminance (10Hz) · Temperature (1Hz)
-
-**Input**: Game Controller (50Hz) · Microphone
-
-**Status**: Battery (1Hz)
+- **Motion**: IMU (100Hz) · Magnetometer (100Hz) · GPS (1Hz) · Proximity (10Hz)
+- **Perception**: Camera (15Hz) · LiDAR (10Hz)
+- **Environment**: Barometer (10Hz) · Illuminance (10Hz) · Temperature (1Hz)
+- **Input**: Game Controller (50Hz) · Microphone
+- **Status**: Battery (1Hz)
 
 ---
 
@@ -142,7 +133,6 @@ See [TRANSPORTS.md](docs/TRANSPORTS.md) for a detailed comparison.
 <b>3. Start Publishing</b><br>
 <sub>Select sensors and stream to ROS 2</sub>
 </td>
-<td width="25%"></td>
 </tr>
 </table>
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -59,8 +59,16 @@ See [TRANSPORTS.md](TRANSPORTS.md) for a deeper side-by-side comparison and netw
    source /opt/ros/jazzy/setup.bash
    export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
    export ROS_DOMAIN_ID=0  # Valid range: 0-232
+
+   # Restart the cached ros2 daemon so it picks up the new RMW.
+   # Skip this on a fresh shell where the daemon hasn't started yet.
+   ros2 daemon stop
+   ros2 daemon start          # optional — `ros2 topic list` autostarts it
+
    ros2 topic list  # Verify the RMW is active (no topics expected yet)
    ```
+
+   **Re-run `ros2 daemon stop` whenever you change `RMW_IMPLEMENTATION`, `ROS_DOMAIN_ID`, `CYCLONEDDS_URI`, or the unicast peer list.** The daemon caches the first context it saw and silently ignores later env-var changes — symptoms include `ros2 topic list` showing topics from the wrong domain, missing the iOS topics entirely, or "topic exists but no data". See [TROUBLESHOOTING.md](TROUBLESHOOTING.md#ros2-cli-shows-stale-topics-after-changing-rmw_implementation-or-cyclonedds_uri).
 
 2. In the Conduit app:
    - Tap Settings → Transport: **DDS**
@@ -152,25 +160,28 @@ For production use, you need a ROS 2 system (Humble, Jazzy, Kilted, or Rolling) 
 
 ### How do I enable background mode?
 
+Background mode is a premium In-App Purchase. After unlocking it:
+
 1. Tap Settings → Enable "Background Mode"
 2. Grant location permission if using GPS
 
 **Limitations:**
 - GPS background tracking not supported (privacy constraints)
-- Camera and LiDAR stop in background (iOS restrictions)
-- Only IMU, GPS (foreground), Magnetometer, Barometer, Battery, Thermal continue in background
+- Camera, LiDAR, and Microphone stop in background (iOS restrictions on ARKit and audio session)
+- Only IMU, GPS (foreground only), Magnetometer, Barometer, Battery, Thermal continue in background
 
 ### What are the premium features?
 
 **Free features:**
 - IMU, GPS, Magnetometer, Barometer, Battery, Thermal, Proximity, Illuminance, **Microphone**
 - Front camera
-- Background processing mode (basic)
 
-**Premium features** (In-App Purchase):
-- **LiDAR sensor** - Point cloud depth sensing
-- **Multi-camera** - Wide, ultra-wide, telephoto cameras
-- **Game Controller** - Bluetooth controller input
+**Premium features** (one-time In-App Purchase per feature):
+- **Multi-camera** — Wide, ultra-wide, telephoto cameras (front camera stays free)
+- **LiDAR sensor** — Point cloud depth sensing (iPhone Pro / iPad Pro / Vision Pro)
+- **Game Controller** — MFi / Bluetooth controller input
+- **Background mode** — Continue publishing supported sensors when the app is backgrounded
+- **MCAP Recording** — Record live topics to a local `.mcap` file for replay in Foxglove or `ros2 bag play`
 
 ### How do I verify data is being published?
 
@@ -339,6 +350,39 @@ No. iOS restricts microphone access to foreground apps only. The microphone stop
 
 Keep the app in the foreground when using the Microphone sensor.
 
+---
+
+## MCAP Recording
+
+### How does MCAP recording work?
+
+When you start a recording, Conduit writes every published topic — same XCDR v1 bytes as the live Zenoh / DDS publish path — to a local `.mcap` file in the app's Documents directory. Schemas are embedded in the MCAP header automatically, so the bag round-trips through any MCAP-aware reader (Foxglove, `ros2 bag play`, the `mcap` CLI) without external `.msg` files.
+
+Recordings are saved on-device only. Conduit never uploads them. From the in-app Recordings list you can share a recording via the system share sheet (Files, AirDrop, mail, …) or delete it.
+
+### Can I record while publishing live to ROS 2?
+
+Yes. Recording is a tee on the same publish path, not a separate pipeline — every message you send to ROS 2 is also written to the bag.
+
+### How do I replay an MCAP file?
+
+```bash
+# Foxglove Studio: File → Open → select the .mcap
+
+# ros2 bag (Jazzy / Kilted / Rolling — bundled mcap_storage_plugin):
+ros2 bag play recording.mcap
+
+# Humble: install ros-humble-rosbag2-storage-mcap first
+sudo apt install ros-humble-rosbag2-storage-mcap
+ros2 bag play recording.mcap --storage mcap
+```
+
+### Why is the Recording button greyed out?
+
+MCAP Recording is a one-time In-App Purchase (see [premium features](#what-are-the-premium-features)). After unlocking it, the Recording control becomes active in the FAB mode selector.
+
+---
+
 ### Does Conduit work offline?
 
 No. Conduit requires network connectivity to:
@@ -367,4 +411,4 @@ This will clear:
 
 Firebase Analytics collects anonymous app usage statistics only (opt-out available in iOS Settings).
 
-See our [Privacy Policy](https://www.youtalk.jp/conduit/#privacy-policy) for details.
+See our [Privacy Policy](../PRIVACY.md) for details.

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -208,13 +208,15 @@ ros2 topic echo /conduit/camera/front/camera_info \
 **Status**: By design (business model)
 
 **Free Sensors**:
-- IMU, GPS, Magnetic Field, Proximity, Barometer, Illuminance, Battery, Thermal
+- IMU, GPS, Magnetic Field, Proximity, Barometer, Illuminance, Battery, Thermal, **Microphone**
 - Front camera
 
-**Premium Sensors**:
+**Premium Sensors / Features** (one-time In-App Purchase per item):
 - LiDAR
-- Wide/Ultra-wide/Telephoto cameras
+- Wide / Ultra-wide / Telephoto cameras
 - Game Controller
+- **Background mode** — keep publishing while the app is backgrounded
+- **MCAP Recording** — record live topics to a local `.mcap` file
 
 ### Premium Purchases Not Syncing
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -337,6 +337,8 @@ Common issues and solutions for Conduit.
 
 **Solutions:**
 
+0. **Restart the cached `ros2` daemon first** — if you changed `RMW_IMPLEMENTATION`, `ROS_DOMAIN_ID`, or `CYCLONEDDS_URI` in this shell, the daemon is still running with the old context and will lie to you. Run `ros2 daemon stop` before any of the checks below. See [`ros2` CLI shows stale topics after changing `RMW_IMPLEMENTATION` or `CYCLONEDDS_URI`](#ros2-cli-shows-stale-topics-after-changing-rmw_implementation-or-cyclonedds_uri) for the full failure mode.
+
 1. **Verify RMW implementation:**
    ```bash
    echo $RMW_IMPLEMENTATION


### PR DESCRIPTION
## Summary

- Replace the App Store shield badge with the actual app icon as a clickable Download button (matching the visual style on https://www.youtalk.jp/conduit/), plus a secondary icon-based button below the tagline.
- Add a **Built on swift-ros2** section explaining that the ROS 2 wire work (Zenoh + DDS, XCDR v1, Humble/Jazzy/Kilted/Rolling codecs) is delegated to [`youtalk/swift-ros2`](https://github.com/youtalk/swift-ros2), and call out that swift-ros2 covers iOS / iPadOS / macOS / Mac Catalyst / visionOS / Linux / Windows / Android.
- Add a traction line under the title: **10,000+ ROS 2 developers worldwide**, peaked **#4 in the App Store's Developer Tools category (Japan)** since January 2026.
- Canonicalize the App Store link to `https://apps.apple.com/app/id6757171237` (drop the `?l=en-US` Japan-store query).
- Port the full privacy policy from https://www.youtalk.jp/conduit/#privacy-policy into a new `PRIVACY.md` at the repo root, link it from the README's **Documentation** and **Links** sections (replacing the external anchor link). Microphone and Proximity rows were added because they ship in the app but were missing from the website's permission/sensor list, the GID-in-Keychain detail was added, and the DDS transport path is now mentioned alongside Zenoh.

## Test plan

- [ ] GitHub renders the README app-icon button as a link to the App Store
- [ ] The "Built on swift-ros2" section links resolve to https://github.com/youtalk/swift-ros2
- [ ] `PRIVACY.md` renders correctly and the README Documentation/Links rows point to it via relative path
- [ ] No remaining `#privacy-policy` external anchor links in the README