### PR TITLE
feat: embed demo videos on the site, add Cyclone DDS and MCAP demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,23 @@ Used cumulatively by **10,000+ ROS 2 developers worldwide** — has ranked as hi
 <sub>Step-by-step guide to connect Conduit with your ROS 2 system</sub>
 </td>
 </tr>
+<tr>
+<td align="center" width="33%">
+<a href="https://www.youtube.com/watch?v=TgNgDvFeAMs">
+<img src="https://img.youtube.com/vi/TgNgDvFeAMs/0.jpg" width="280" alt="Cyclone DDS Demo"><br>
+<b>Cyclone DDS</b>
+</a><br>
+<sub>Native ROS 2 communication over Cyclone DDS — no Zenoh router, no bridge</sub>
+</td>
+<td align="center" width="33%">
+<a href="https://www.youtube.com/watch?v=yhI3eWcWSNQ">
+<img src="https://img.youtube.com/vi/yhI3eWcWSNQ/0.jpg" width="280" alt="MCAP Recording Demo"><br>
+<b>MCAP Recording</b>
+</a><br>
+<sub>Record every topic and export an MCAP file for Foxglove or ros2 bag</sub>
+</td>
+<td align="center" width="33%"></td>
+</tr>
 </table>
 
 ---

--- a/scripts/sync_readme.py
+++ b/scripts/sync_readme.py
@@ -1,6 +1,6 @@
 """MkDocs on_pre_build hook: regenerate docs/index.md from README.md.
 
-Three responsibilities:
+Four responsibilities:
 
 1. Rewrite image paths (``images/`` → ``assets/img/``) so the same Markdown
    source works as both the GitHub README and the MkDocs home page.
@@ -9,6 +9,10 @@ Three responsibilities:
 3. Replace the README's centered icon + ``# Conduit`` heading block with a
    custom HTML hero that matches the Conduit app's design language. The hero
    ships inside ``index.md`` and is styled by ``docs/assets/css/conduit.css``.
+4. Turn demo-video thumbnails (a YouTube thumbnail image linked to the watch
+   page) into inline ``<iframe>`` players: GitHub strips ``<iframe>`` from
+   README markup, so the README keeps the clickable thumbnails while the
+   MkDocs site gets real embedded players.
 """
 from __future__ import annotations
 
@@ -32,6 +36,18 @@ _BARE_DOC_RE = re.compile(
 _HTML_ATTR_RE = re.compile(r'(\b(?:src|href)=")images/')
 # ](images/...)
 _MD_INLINE_RE = re.compile(r"\]\(images/")
+# A demo-video cell: <a href="...watch?v=ID"> wrapping a YouTube thumbnail
+# <img> and a <b>Title</b>. Rewritten to an inline <iframe> player for the
+# site (GitHub strips <iframe>, so README keeps the thumbnail link).
+_YT_THUMB_RE = re.compile(
+    r'<a href="https://www\.youtube\.com/watch\?v=([\w-]+)">\s*'
+    r"<img[^>]*>\s*<br>\s*"
+    r"<b>([^<]+)</b>\s*</a>"
+)
+_YT_IFRAME_ALLOW = (
+    "accelerometer; autoplay; clipboard-write; encrypted-media; "
+    "gyroscope; picture-in-picture; web-share"
+)
 
 # ----- Hero replacement -----
 
@@ -122,6 +138,18 @@ def rewrite(text: str) -> str:
     def _hero_repl(match: re.Match[str]) -> str:
         return _HERO_HTML.format(app_url=match.group("app_url"))
 
+    def _yt_repl(match: re.Match[str]) -> str:
+        video_id, title = match.group(1), match.group(2)
+        return (
+            f'<iframe width="100%" height="170" '
+            f'src="https://www.youtube.com/embed/{video_id}" '
+            f'title="{title}" frameborder="0" '
+            f'allow="{_YT_IFRAME_ALLOW}" '
+            f'referrerpolicy="strict-origin-when-cross-origin" '
+            f"allowfullscreen></iframe><br>\n"
+            f"<b>{title}</b>"
+        )
+
     text = _HERO_BLOCK_RE.sub(_hero_repl, text, count=1)
     text = _DOCS_LINK_RE.sub(_docs_repl, text)
     text = _DOCKER_README_RE.sub(
@@ -131,6 +159,7 @@ def rewrite(text: str) -> str:
     text = _BARE_DOC_RE.sub(_bare_repl, text)
     text = _HTML_ATTR_RE.sub(r'\1assets/img/', text)
     text = _MD_INLINE_RE.sub("](assets/img/", text)
+    text = _YT_THUMB_RE.sub(_yt_repl, text)
     return text
 
 

--- a/tests/test_sync_readme.py
+++ b/tests/test_sync_readme.py
@@ -120,3 +120,38 @@ def test_hero_replacement_only_runs_once():
     """A page that doesn't open with the centered block isn't touched."""
     src = "## Section\n\nNo hero here.\n"
     assert sync_readme.rewrite(src) == src
+
+
+_DEMO_CELL = (
+    '<a href="https://www.youtube.com/watch?v=d28sQYQlpYY">\n'
+    '<img src="https://img.youtube.com/vi/d28sQYQlpYY/0.jpg" width="280" '
+    'alt="Teleoperation Demo"><br>\n'
+    "<b>Teleoperation</b>\n"
+    "</a><br>\n"
+    "<sub>Control robots using Game Controller sensor</sub>"
+)
+
+
+def test_demo_thumbnail_becomes_iframe_embed():
+    out = sync_readme.rewrite(_DEMO_CELL)
+    assert 'src="https://www.youtube.com/embed/d28sQYQlpYY"' in out
+    assert "<iframe" in out
+    # Title and surrounding caption are preserved.
+    assert "<b>Teleoperation</b>" in out
+    assert "<sub>Control robots using Game Controller sensor</sub>" in out
+    # The clickable watch-page link is gone — it became the iframe player.
+    assert "youtube.com/watch?v=" not in out
+
+
+def test_demo_thumbnail_rewrite_is_idempotent():
+    once = sync_readme.rewrite(_DEMO_CELL)
+    assert sync_readme.rewrite(once) == once
+
+
+def test_non_youtube_anchor_with_image_is_untouched():
+    src = (
+        '<a href="https://example.com/page">\n'
+        '<img src="https://img.youtube.com/vi/x/0.jpg"><br>\n'
+        "<b>Not a video</b>\n</a>"
+    )
+    assert sync_readme.rewrite(src) == src


### PR DESCRIPTION
## Summary

Two related changes to the **Demo Videos** section of the support site:

1. **Add two new demos** — the two newly published YouTube videos:
   - **Cyclone DDS** — Native ROS 2 communication over Cyclone DDS, no Zenoh router / no bridge (`TgNgDvFeAMs`)
   - **MCAP Recording** — Record every topic and export an MCAP file for Foxglove or `ros2 bag` (`yhI3eWcWSNQ`)

   The 3-column table now spans two rows to hold all five demos.

2. **Embed videos as iframe players on the site** — GitHub strips `<iframe>` from README markup, so `README.md` keeps the clickable YouTube thumbnails. The `sync_readme.py` MkDocs hook now rewrites each thumbnail-link cell into an inline `<iframe>` player when generating `docs/index.md`, so the published site (conduit.youtalk.jp) gets real embedded players while the GitHub repo landing keeps thumbnails.

## Verification

- `pytest tests/` — 16 passed (3 new tests cover the iframe rewrite, idempotency, and non-YouTube anchors left untouched)
- `mkdocs build --strict` passes
- Built `index.html` contains all five videos as `youtube.com/embed/...` iframes, with no leftover `watch?v=` links
- `README.md` still renders the five thumbnail links unchanged